### PR TITLE
Use argparse to parse CLI arguments

### DIFF
--- a/gene2fasta.py
+++ b/gene2fasta.py
@@ -61,10 +61,10 @@ def main():
             # writing the sequences    
             wmRNA = "\n".join(lmRNA)
             wprotein = "\n".join(lprotein)
-            if option_mRNA == 1:
+            if args.mrna:
                 with open(out_name + "_mRNA.fasta", mode="a") as f:
                     f.write(wmRNA)
-            if option_protein == 1:
+            if args.protein:
                 with open(out_name + "_protein.fasta", mode="a") as f:
                     f.write(wprotein)
 
@@ -87,7 +87,7 @@ def dumpingGENETABLE(gene_table, mRNA_flag, protein_flag, CDS_flag, splicing_fla
     print(mRNA_list)
 
     # only 1 seq extraction if "splicing flag" = 0
-    if splicing_flag:
+    if not splicing_flag:
         del mRNA_list[1:]
 
     mRNA_fasta = []
@@ -95,7 +95,7 @@ def dumpingGENETABLE(gene_table, mRNA_flag, protein_flag, CDS_flag, splicing_fla
         # get nucleotide fasta sequence from NCBI database
         for i in range(len(mRNA_list)):
             try:    
-                if CDS_flag: # get all sequence
+                if not CDS_flag: # get all sequence
                     tmp_fasta = requests.get("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id={}&rettype=fasta&retmode=text".format(mRNA_list[i]))
                 else: # get only CDS sequence
                     tmp_fasta = requests.get("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id={}&rettype=fasta_cds_na&retmode=text".format(mRNA_list[i]))

--- a/gene2fasta.py
+++ b/gene2fasta.py
@@ -1,3 +1,4 @@
+import argparse
 import sys
 import numpy as np
 import pandas as pd
@@ -7,18 +8,21 @@ import datetime
 import os
 
 def main():
-    importfile = sys.argv[1] # tsvfile input
-    option_mRNA = int(sys.argv[2]) # if mRNA seq needed, 1
-    option_protein = int(sys.argv[3]) # if protein seq needed, 1
-    option_CDS = int(sys.argv[4]) # if CDS sequence you need, 1
-    option_splicing = int(sys.argv[5]) # if you need all splicing variants, 1
+    parser = argparse.ArgumentParser(description="Convert geneID(NCBI) to FASTA (mRNA, CDS, protein/amino acid sequences).")
+    parser.add_argument("importfile", type=str, help="TSV file input")
+    parser.add_argument("--mrna", action="store_true", default=False, help="if you need mRNA seq")
+    parser.add_argument("--protein", action="store_true", default=False, help="If you need protein seq")
+    parser.add_argument("--cds", action="store_true", default=False, help="if you need CDS seq")
+    parser.add_argument("--splising", action="store_true", default=False, help="if you need all splicing variants")
+
+    args = parser.parse_args()
 
     #set output file name
     now = datetime.datetime.now()
-    out_name = os.path.basename(importfile) + "_{0:%Y%m%d%H%M%S}".format(now)
+    out_name = os.path.basename(args.importfile) + "_{0:%Y%m%d%H%M%S}".format(now)
     
     # open tsv file and extract
-    indf = pd.read_csv(importfile, sep="\t")
+    indf = pd.read_csv(args.importfile, sep="\t")
     geneid = indf["GeneID"].values.tolist()
     print("Gene IDs are : " + str(geneid))
     print("input file number is : " + str(len(geneid)))
@@ -28,7 +32,7 @@ def main():
         try:
             gene_table = requests.get("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=gene&id={}&rettype=gene_table&retmode=text".format(i))
             # get fasta format sequences as list
-            lmRNA, lprotein = dumpingGENETABLE(gene_table.text, option_mRNA, option_protein, option_CDS, option_splicing)
+            lmRNA, lprotein = dumpingGENETABLE(gene_table.text, args.mrna, args.protein, args.cds, args.splicing)
 
             # writing the sequences    
             wmRNA = "\n".join(lmRNA)
@@ -42,10 +46,6 @@ def main():
 
         except requests.exceptions.RequestException as err:
             print(err)    
-        
-
-
-
 
 
 def dumpingGENETABLE(gene_table, mRNA_flag, protein_flag, CDS_flag, splicing_flag):
@@ -63,17 +63,17 @@ def dumpingGENETABLE(gene_table, mRNA_flag, protein_flag, CDS_flag, splicing_fla
     print(mRNA_list)
 
     # only 1 seq extraction if "splicing flag" = 0
-    if splicing_flag == 0:
+    if splicing_flag:
         del mRNA_list[1:]
 
     mRNA_fasta = []
-    if mRNA_flag == 1:
+    if mRNA_flag:
         # get nucleotide fasta sequence from NCBI database
         for i in range(len(mRNA_list)):
             try:    
-                if CDS_flag == 0: # get all sequence
+                if CDS_flag: # get all sequence
                     tmp_fasta = requests.get("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id={}&rettype=fasta&retmode=text".format(mRNA_list[i]))
-                elif CDS_flag == 1: # get only CDS sequence
+                else: # get only CDS sequence
                     tmp_fasta = requests.get("https://eutils.ncbi.nlm.nih.gov/entrez/eutils/efetch.fcgi?db=nuccore&id={}&rettype=fasta_cds_na&retmode=text".format(mRNA_list[i]))
                 #print(tmp_fasta.text)
                 mRNA_fasta.append(tmp_fasta.text)
@@ -85,7 +85,7 @@ def dumpingGENETABLE(gene_table, mRNA_flag, protein_flag, CDS_flag, splicing_fla
         MmRNA_fasta = []
 
     protein_fasta = []
-    if protein_flag == 1:
+    if protein_flag:
         # get protein fasta sequence
         for i in range(len(mRNA_list)):
             try:


### PR DESCRIPTION
Parsing `sys.argv` directly is not a general way. Python3 has a CLI arguments parser library called `argparse`. 

### Changes

- Path to input file as positional arguments
    - Like `python gene2fasta.py XXX.tsv`
- Use boolean flag instead of integer value
    - Like `python gene2fasta.py XXXX.tsv --mrna --protein --cds --splicing`
    - If no options were provided, they are interpreted as `False`

### Note

- You can specify them in a different order.
    - Both `python gene2fasta.py XXXX.tsv --mrna` and `python gene2fasta.py --mrna XXXX.tsv`  are available.
- You can show the help message of this command with `-h` or `--help` flag.

```bash
$ python gene2fasta.py -h
usage: gene2fasta.py [-h] [--mrna] [--protein] [--cds] [--splising] importfile

Convert geneID(NCBI) to FASTA (mRNA, CDS, protein/amino acid sequences).

positional arguments:
  importfile  TSV file input

optional arguments:
  -h, --help  show this help message and exit
  --mrna      if you need mRNA seq
  --protein   If you need protein seq
  --cds       if you need CDS seq
  --splising  if you need all splicing variants
```

### Caution

I didn't confirm that these changes don't break the behavior. I'm glad if you can verify it.